### PR TITLE
Fix tracking of OnlinePlayers metric and bump Lombok version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>github.metalshark.cloudwatch</groupId>
     <artifactId>CloudWatch</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
 
     <name>CloudWatch</name>
     <description>CloudWatch statistic logging for Minecraft Servers.</description>
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.12</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/github/metalshark/cloudwatch/CloudWatch.java
+++ b/src/main/java/github/metalshark/cloudwatch/CloudWatch.java
@@ -10,6 +10,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.event.world.ChunkUnloadEvent;
 import org.bukkit.plugin.PluginManager;
@@ -65,7 +66,7 @@ public class CloudWatch extends JavaPlugin {
         final PluginManager pluginManager = Bukkit.getPluginManager();
 
         pluginManager.registerEvents(chunkLoadListener.init(), this);
-        pluginManager.registerEvents(playerJoinListener, this);
+        pluginManager.registerEvents(playerJoinListener.init(), this);
 
         eventCountListeners.put("ChunksPopulated", new ChunkPopulateListener());
         eventCountListeners.put("CreaturesSpawned", new CreatureSpawnListener());
@@ -102,6 +103,7 @@ public class CloudWatch extends JavaPlugin {
         ChunkLoadEvent.getHandlerList().unregister(chunkLoadListener);
         ChunkUnloadEvent.getHandlerList().unregister(chunkLoadListener);
         PlayerJoinEvent.getHandlerList().unregister(playerJoinListener);
+        PlayerQuitEvent.getHandlerList().unregister(playerJoinListener);
 
         for (Map.Entry<String, EventCountListener> entry : eventCountListeners.entrySet()) {
             final Listener listener = entry.getValue();

--- a/src/main/java/github/metalshark/cloudwatch/listeners/PlayerJoinListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/PlayerJoinListener.java
@@ -1,26 +1,42 @@
 package github.metalshark.cloudwatch.listeners;
 
 import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 public class PlayerJoinListener implements Listener {
 
-    private double maxOnlinePlayers = 0;
+    private double count = 0;
+    private double max = 0;
+
+    public PlayerJoinListener init() {
+        for (World world : Bukkit.getWorlds()) {
+            count = world.getPlayers().size();
+        }
+        return this;
+    }
 
     @EventHandler(priority=EventPriority.MONITOR)
     @SuppressWarnings("unused")
     public void onPlayerJoin(PlayerJoinEvent event) {
-        final double onlinePlayers = Bukkit.getOnlinePlayers().size();
-        if (onlinePlayers > maxOnlinePlayers) maxOnlinePlayers = onlinePlayers;
+        count++;
+        if (count > max) max = count;
     }
 
-    public double getMaxOnlinePlayersAndReset() {
-        final double prevMaxOnlinePlayers = maxOnlinePlayers;
-        maxOnlinePlayers = 0;
-        return prevMaxOnlinePlayers;
+    @EventHandler(priority = EventPriority.MONITOR)
+    @SuppressWarnings("unused")
+    public void onPlayerLeave(PlayerQuitEvent event) {
+        count--;
+    }
+
+    public double getMaxAndReset() {
+        final double prevMax = max;
+        max = count;
+        return prevMax;
     }
 
 }

--- a/src/main/java/github/metalshark/cloudwatch/runnables/MinecraftStatisticsRunnable.java
+++ b/src/main/java/github/metalshark/cloudwatch/runnables/MinecraftStatisticsRunnable.java
@@ -19,7 +19,7 @@ public class MinecraftStatisticsRunnable implements Runnable {
         final double chunksLoaded = chunkLoadListener.getMaxAndReset();
 
         final PlayerJoinListener playerJoinListener = plugin.getPlayerJoinListener();
-        final double onlinePlayers = playerJoinListener.getMaxOnlinePlayersAndReset();
+        final double onlinePlayers = playerJoinListener.getMaxAndReset();
 
         final TickRunnable tickRunnable = plugin.getTickRunnable();
         final double maxTickTime = tickRunnable.getMaxElapsedMillisAndReset();


### PR DESCRIPTION
Currently `PlayerJoinListener` only tracks when players join, not when they leave. The value is set to zero (rather than the updated player count) periodically by the `MinecraftStatisticsRunnable`. This results in the `OnlinePlayers` metric representing player logins for a given time window, rather than being a metric of how many players are online.

Modifying `PlayerJoinListener` to work like `ChunkLoadListener` (with `PlayerQuitEvent` being used as the "unload" event) fixes this.

The Lombok version bump is necessary to make the target JAR compatible with Minecraft 1.20.

Tested on Paper 1.20.2.